### PR TITLE
use signals from nested interfaces

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/EventSignalsFromInterfaces.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/EventSignalsFromInterfaces.cs
@@ -12,6 +12,10 @@ namespace Godot.SourceGenerators.Sample
         public delegate void OnHealthChangedEventHandler(int health);
     }
 
+    public interface INested : IHealth
+    {
+    }
+
     public interface ISpell
     {
         [Signal]
@@ -33,6 +37,14 @@ namespace Godot.SourceGenerators.Sample
     }
 
     public partial class EventSignalsFromInterfacesSecond : Node, IHealth
+    {
+        public override void _Ready()
+        {
+            OnHealthChanged += (int health) => { GD.Print($"{nameof(OnHealthChanged)} {health}"); };
+        }
+    }
+
+    public partial class EventSignalsFromInterfacesThird : Node, INested
     {
         public override void _Ready()
         {

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSignalsGenerator.cs
@@ -126,7 +126,7 @@ namespace Godot.SourceGenerators
             var members = symbol.GetMembers();
 
             // Parse interfaces associated with this class and try to generate signals in the current class symbol
-            var interfaceSignalDelegateSymbols = symbol.Interfaces
+            var interfaceSignalDelegateSymbols = symbol.AllInterfaces
                 .Where(s => s.TypeKind == TypeKind.Interface && s.Kind == SymbolKind.NamedType)
                 .Cast<INamedTypeSymbol>()
                 .Select(n => n.GetMembers()


### PR DESCRIPTION
Fixes 2) from my comment at https://github.com/godotengine/godot/pull/83889

What was the intent of using symbol.Interfaces instead of symbol.AllInterfaces? Some kind of edge case? Performace reasons? Perhaps I did it wrong and it needs more work.